### PR TITLE
Only upload on builds against master branch

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,8 +7,10 @@ if [ -z "${TRAVIS_BRANCH:-}" ]; then
     exit 1
 fi
 
-if [ "$TRAVIS_BRANCH" != "master" ]; then
-    echo "This commit was made against '$TRAVIS_BRANCH' and not master! No deploy!"
+BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+
+if [ "$BRANCH" != "master" ]; then
+    echo "This commit was made against '$BRANCH' and not master! No deploy!"
     exit 0
 fi
 


### PR DESCRIPTION
Looks like the `TRAVIS_BRANCH` variable uses the target branch for PR builds rather than the source. So all PRs will actually replace the `gh-pages` branch.

I've pilfered an alternative way to get the branch name in travis from [here](https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/) that reports the source branch properly.

Just going to make sure this PR itself doesn't trigger the docs to upload, and that an upload is triggered when it's merged.