### PR TITLE
Suggest using version-sync to keep html_root_url in sync

### DIFF
--- a/src/documentation.md
+++ b/src/documentation.md
@@ -206,11 +206,16 @@ incorrect.
 ```
 
 Because this URL contains an exact version number, it must be kept in
-sync with the version number in `Cargo.toml`. Unfortunately there is
-no mechanism in Rust today to eliminate this duplication, so
-the current recommendation is to add a comment to the `Cargo.toml`
-version key reminding yourself to keep the two updated together,
-like:
+sync with the version number in `Cargo.toml`. The [`version-sync`]
+crate can help with this by letting you add an integration test that
+fails if the `html_root_url` version number is out of sync with the
+crate version.
+
+[`version-sync`]: https://crates.io/crates/version-sync
+
+If you do not like that mechanism, it is recommended to add a comment
+to the `Cargo.toml` version key reminding yourself to keep the two
+updated together, like:
 
 ```toml
 version = "0.3.8" # remember to update html_root_url

--- a/src/documentation.md
+++ b/src/documentation.md
@@ -193,8 +193,8 @@ but should be considered carefully.
 <a id="c-html-root"></a>
 ### Crate sets html_root_url attribute (C-HTML-ROOT)
 
-It should point to `"https://docs.rs/CRATE/VER.SI.ON"`, assuming the crate
-uses docs.rs for its primary API documentation.
+It should point to `"https://docs.rs/CRATE/MAJOR.MINOR.PATCH"`,
+assuming the crate uses docs.rs for its primary API documentation.
 
 The `html_root_url` attribute tells rustdoc how to create URLs to
 items in the crate when compiling downstream crates. Without it, links


### PR DESCRIPTION
I wrote a little helper crate for keeping version numbers in sync with the crate version: https://crates.io/crates/version-sync. I hope it will be useful to people reading the guidelines and humbly suggest including it.