### PR TITLE
Fix typo

### DIFF
--- a/src/predictability.md
+++ b/src/predictability.md
@@ -187,7 +187,7 @@ conventions for their constructors, as in [`File::open`], [`Mmap::open`],
 as appropriate for the domain.
 
 Often there are multiple ways to construct a type. It's common in these cases
-for secondary constructors to be be suffixed, `_with_foo`, as in
+for secondary constructors to be suffixed `_with_foo`, as in
 [`Mmap::open_with_offset`]. If your type has a multiplicity of construction
 options though, consider the builder pattern ([C-BUILDER]) instead.
 


### PR DESCRIPTION
I also removed a comma, as I consider the `_with_foo` snippet to be part of the sentence/flow. Feel free to edit, if you disagree.