### PR TITLE
necessities: Use "MIT OR Apache-2.0"

### DIFF
--- a/src/necessities.md
+++ b/src/necessities.md
@@ -66,7 +66,7 @@ To apply the Rust license to your project, define the `license` field in your
 name = "..."
 version = "..."
 authors = ["..."]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 ```
 
 And toward the end of your README.md:


### PR DESCRIPTION
Catch up with rust-lang/cargo#4898, which deprecated '/' in favor of vanilla SPDX license expressions.