### PR TITLE
book.toml: Add a [book] table (and a description)

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,1 +1,3 @@
+[book]
 title = "Rust API Guidelines"
+description = "This is a set of recommendations on how to design and present APIs for the Rust programming language."


### PR DESCRIPTION
[Avoid][1]:

```console
$ mdbook build
2018-04-17 22:35:25 [WARN] (mdbook::config): It looks like you are using the legacy book.toml format.
2018-04-17 22:35:25 [WARN] (mdbook::config): We'll parse it for now, but you should probably convert to the new format.
2018-04-17 22:35:25 [WARN] (mdbook::config): See the mdbook documentation for more details, although as a rule of thumb
2018-04-17 22:35:25 [WARN] (mdbook::config): just move all top level configuration entries like `title`, `author` and
2018-04-17 22:35:25 [WARN] (mdbook::config): `description` under a table called `[book]`, move the `destination` entry
2018-04-17 22:35:25 [WARN] (mdbook::config): from `[output.html]`, renamed to `build-dir`, under a table called
2018-04-17 22:35:25 [WARN] (mdbook::config): `[build]`, and it should all work.
2018-04-17 22:35:25 [WARN] (mdbook::config): Documentation: http://rust-lang-nursery.github.io/mdBook/format/config.html
2018-04-17 22:35:25 [INFO] (mdbook::book): Book building has started
…
```

I've added the suggested `[book]`.  And while I'm touching the file, I've also copied the first sentence from the README into the `description` entry.

[1]: https://travis-ci.org/rust-lang-nursery/api-guidelines/builds/367895578#L490