### PR TITLE
Remove try_main and return Result

### DIFF
--- a/src/documentation.md
+++ b/src/documentation.md
@@ -51,16 +51,12 @@ will not appear in user-visible rustdoc.
 /// ```rust
 /// # use std::error::Error;
 /// #
-/// # fn try_main() -> Result<(), Box<Error>> {
+/// # fn main() -> Result<(), Box<Error>> {
 /// your;
 /// example?;
 /// code;
 /// #
 /// #     Ok(())
-/// # }
-/// #
-/// # fn main() {
-/// #     try_main().unwrap();
 /// # }
 /// ```
 ```


### PR DESCRIPTION
Since main can now return a result, the documentation examples that use `?` can be simplified. This is also the method used by the [rustdoc documentation](https://doc.rust-lang.org/rustdoc/documentation-tests.html).