### PR TITLE
src/interoperability: change “url” to “Url”

### DIFF
--- a/src/interoperability.md
+++ b/src/interoperability.md
@@ -15,7 +15,7 @@ To see why, consider the following situation:
 * Crate `url` defines type `Url`, without implementing `Display`.
 * Crate `webapp` imports from both `std` and `url`,
 
-There is no way for `webapp` to add `Display` to `url`, since it defines
+There is no way for `webapp` to add `Display` to `Url`, since it defines
 neither. (Note: the newtype pattern can provide an efficient, but inconvenient
 workaround.)
 


### PR DESCRIPTION
In the “C-COMMON-TRAITS” section of “Interoperability”, the following text appears:

> There is no way for `webapp` to add `Display` to `url`, …

This seems to say “implement `Display` for `url` (the crate)” instead of “implement `Display` for `url::Url` (the type)”.

This pull request fixes this, by capitalizing “`url`” into “`Url`”.