### PR TITLE
C-PERMISSIVE: Use autolinks

### DIFF
--- a/src/necessities.md
+++ b/src/necessities.md
@@ -82,9 +82,9 @@ And toward the end of your README.md:
 Licensed under either of
 
  * Apache License, Version 2.0
-   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+   ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 


### PR DESCRIPTION
This is done so that non-GFM-compatible markdown parsers can identify the links. Examples include rustdoc and the one that ships with cgit-pink.

Closes https://github.com/rust-lang/api-guidelines/issues/281