### PR TITLE
Methods named `len`, `is_empty` and `capacity` should take constant time

### DIFF
--- a/src/predictability.md
+++ b/src/predictability.md
@@ -131,6 +131,26 @@ so on for the other traits.
 
 [`std::ops`]: https://doc.rust-lang.org/std/ops/index.html#traits
 
+<a id="c-constant-time-methods"></a>
+
+## Methods `len`, `is_empty` and `capacity` take constant time (C-CONSTANT-TIME-METHODS)
+
+The [time complexity] for methods named `len`, `is_empty` and `capacity` should be **O(1)** -
+it should always take the same amount of time to run these methods regardless of
+how large the collection is.
+
+If you need to count elements by iterating, choose a different name for your methods such as `count` or `size`
+
+### Examples from the standard library
+
+- [`Vec::len`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.len)
+- [`Vec::is_empty`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.is_empty)
+- [`Vec::capacity`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.capacity)
+- [`HashMap::len`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.len)
+- [`HashSet::capacity`](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.capacity)
+- [`LinkedList::is_empty`](https://doc.rust-lang.org/std/collections/struct.LinkedList.html#method.is_empty)
+
+[time complexity]: https://en.wikipedia.org/wiki/Time_complexity
 
 <a id="c-deref"></a>
 ## Only smart pointers implement `Deref` and `DerefMut` (C-DEREF)


### PR DESCRIPTION
Today, I wanted to switch to using `Vec::with_capacity` instead of `Vec::new` while iterating over a [`toml_edit::Table`](https://docs.rs/toml_edit/latest/toml_edit/struct.Table.html):

```rs
let v = Vec::with_capacity(table.len());
```

But to my surprise, the [`Table::len`](https://docs.rs/toml_edit/latest/toml_edit/struct.Table.html#method.len) method actually takes **O(n)** time, as it is implemented with `Iterator::count`:

```rs
/// Returns the number of non-empty items in the table.
pub fn len(&self) -> usize {
    self.iter().count()
}

/// Returns true if the table is empty.
pub fn is_empty(&self) -> bool {
    self.len() == 0
}
```

This is surprising and can make people's code slower, without them realizing why. Library authors should choose different names for a `len` method if it doesn't take constant time, such as `count`.

I found a [discussion](https://github.com/rust-lang/api-guidelines/discussions/149) about this from 2017, and decided to open a PR to add this guideline
