### PR TITLE
C-CUSTOM-TYPE: Cover return types + discourage tuples.

### DIFF
--- a/src/type-safety.md
+++ b/src/type-safety.md
@@ -36,29 +36,35 @@ remind us to perform the conversion, thus averting certain [catastrophic bugs].
 
 
 <a id="c-custom-type"></a>
-## Arguments convey meaning through types, not `bool` or `Option` (C-CUSTOM-TYPE)
+## Use specific types as parameter and return types, not `bool` or `Option` (C-CUSTOM-TYPE)
 
 Prefer
 
 ```rust
-let w = Widget::new(Small, Round)
+let w = Widget::new(Size::Small, Shape::Round)
+let Connection { sender, receiver } = create_message_pipe();
 ```
 
 over
 
 ```rust
 let w = Widget::new(true, false)
+let (end1, end2) = open_connection();
 ```
 
-Core types like `bool`, `u8` and `Option` have many possible interpretations.
+Core types like `bool`, `u8`, tuples, and `Option` have many possible
+interpretations.
 
-Use a deliberate type (whether enum, struct, or tuple) to convey interpretation
+Use a deliberate type (enum or struct) to convey interpretation
 and invariants. In the above example, it is not immediately clear what `true`
 and `false` are conveying without looking up the argument names, but `Small` and
-`Round` are more suggestive.
+`Round` are more suggestive.  Similarily, it may be unclear if the first item of
+a returned tuple is a sender or a receiver, but named `sender` and `receiver`
+fields convey this explicitly.
 
 Using custom types makes it easier to expand the options later on, for example
-by adding an `ExtraLarge` variant.
+by adding an `ExtraLarge` variant to the `Size` enum, or by adding more fields
+to the `Connection` struct.
 
 See the newtype pattern ([C-NEWTYPE]) for a no-cost way to wrap existing types
 with a distinguished name.


### PR DESCRIPTION
PTAL?

This PR is an attempt to upstream some Chromium-specific guidelines from https://source.chromium.org/chromium/chromium/src/+/main:docs/rust/api_design.md;l=56-66;drc=e213d50dfa608aba386b151f831d6e25f849bcac.

I hope that covering not only parameter types, but also return types is mostly uncontroversial.

I think that discouraging the use of tuples in public APIs matches the spirit of the rule.  I understand that sometimes the meaning of tuples is obvious from the context - e.g. it seems totally fine to return a tuple from [`unzip`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.unzip).  But I think that the situation here is similar to a `bool` return type - it may be sometimes okay to return a `bool` (e.g. from [`is_empty`](https://doc.rust-lang.org/std/primitive.slice.html#method.is_empty) or from `is_small` or `is_round`), but one should still consider using a more specific parameter and/or return type if possible.

The fact that `bool` is okay in many `is_foo` functions makes me wonder if this PR should instead be adding a _new_ rule to the guidelines.  But I think that editing the C-CUSTOM-TYPE rule is still reasonable and keeps things simple.  WDYT?

/cc @dkloehr, @zetafunction, @Manishearth